### PR TITLE
Update c library dependency, fixes #7

### DIFF
--- a/libsystemd-journal.cabal
+++ b/libsystemd-journal.cabal
@@ -1,12 +1,12 @@
 name:                libsystemd-journal
-version:             1.1.0
+version:             1.2.1
 synopsis:            Haskell bindings to libsystemd-journal
 homepage:            http://github.com/ocharles/libsystemd-journal
 license:             BSD3
 license-file:        LICENSE
 author:              Oliver Charles
 maintainer:          ollie@ocharles.org.uk
-copyright: Oliver Charles (c) 2014
+copyright:           Oliver Charles (c) 2014
 category:            System
 build-type:          Custom
 cabal-version:       >=1.10
@@ -16,8 +16,20 @@ extra-source-files:
 
 library
   exposed-modules:     Systemd.Journal
-  build-depends:       base >=4.6 && <4.7, bytestring >= 0.9.1, pipes >= 4.0, pipes-safe >= 2.0, text >= 0.1 && < 1.2, transformers >= 0.3, unix-bytestring >= 0.3.2 && < 0.4, vector >= 0.4 && < 0.11, uuid, unordered-containers >= 0.1 && < 0.3, hashable >= 1.1.2.5, hsyslog, uniplate >= 1.6
+  build-depends:       base >= 4.6 && <4.8,
+                       bytestring >= 0.9.1,
+                       pipes >= 4.0,
+                       pipes-safe >= 2.0,
+                       text >= 0.1 && < 1.3,
+                       transformers >= 0.3,
+                       unix-bytestring >= 0.3.2 && < 0.4,
+                       vector >= 0.4 && < 0.11,
+                       uuid,
+                       unordered-containers >= 0.1 && < 0.3,
+                       hashable >= 1.1.2.5,
+                       hsyslog,
+                       uniplate >= 1.6
   hs-source-dirs:      src
   default-language:    Haskell2010
-  extra-libraries: systemd-journal
-  ghc-options: -Wall
+  extra-libraries:     systemd
+  ghc-options:         -Wall


### PR DESCRIPTION
The Systemd project moved their code from libsystemd-journal to libsystemd. I
updated the c library dependency and bumped the version.

Somehow the version 1.2.0 is missing in the repository. Therefore I skipped this version and went strait to 1.2.1. I hope this is ok.

Best,
Sven
