### PR TITLE
Add seek realtime; Add waiting/terminating mode; Fix GHC warnings

### DIFF
--- a/src/Systemd/Journal.hsc
+++ b/src/Systemd/Journal.hsc
@@ -36,11 +36,10 @@ module Systemd.Journal
     , Direction(..)
     , JournalEntry, JournalEntryCursor
     , journalEntryFields, journalEntryCursor, journalEntryRealtime
-    , JournalFlag (..)
-    , Filter (..)
+    , JournalFlag(..)
+    , Filter(..)
     ) where
 
-import Control.Applicative
 import Control.Monad (when, void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Bits ((.|.))
@@ -350,10 +349,10 @@ openJournal flags start journalFilter threshold =
         return ()
 
       FromEnd d -> void $ do
-        throwIfNeg (("sd_journal_seek_tail: " ++) . show) $
+        _ <- throwIfNeg (("sd_journal_seek_tail: " ++) . show) $
           sdJournalSeekTail journalPtr
         when (d == Forwards) $ do
-          throwIfNeg (("sd_journal_previous_skip" ++) . show) $
+          _ <- throwIfNeg (("sd_journal_previous_skip" ++) . show) $
             sdJournalPreviousSkip journalPtr 1
           return ()
 
@@ -430,7 +429,7 @@ openJournal flags start journalFilter threshold =
                 cursorCString <- peek cursorStrPtr
                 BS.packCString cursorCString <* free cursorCString)
           <*> (alloca $ \realtimePtr -> do
-                sdJournalGetRealtimeUsec journalPtr realtimePtr
+                _ <- sdJournalGetRealtimeUsec journalPtr realtimePtr
                 peek realtimePtr)
 
         Pipes.yield entry
@@ -438,7 +437,7 @@ openJournal flags start journalFilter threshold =
         go journalPtr
 
       EQ -> when (sdJournalDirection == Forwards) $ do
-        liftIO $ sdJournalWait journalPtr (-1)
+        _ <- liftIO $ sdJournalWait journalPtr (-1)
         go journalPtr
 
       LT -> error $ "sd_journal_next: " ++ show progressedBy

--- a/src/Systemd/Journal.hsc
+++ b/src/Systemd/Journal.hsc
@@ -9,6 +9,7 @@ module Systemd.Journal
       sendMessage
     , sendMessageWith
     , sendJournalFields
+    , encodePriority
 
     , JournalFields
 
@@ -120,10 +121,15 @@ messageId =
   HashMap.singleton (JournalField "MESSAGE_ID") . Text.encodeUtf8 . Text.pack . UUID.toString
 
 --------------------------------------------------------------------------------
+-- | A priority value compatible encoded as ByteString
+encodePriority :: Syslog.Priority -> BS.ByteString
+encodePriority = Text.encodeUtf8 .  Text.pack . show . fromEnum
+
+--------------------------------------------------------------------------------
 -- | A priority value compatible with syslog's priority concept.
 priority :: Syslog.Priority -> JournalFields
 priority =
-  HashMap.singleton (JournalField "PRIORITY") . Text.encodeUtf8 .  Text.pack . show . fromEnum
+  HashMap.singleton (JournalField "PRIORITY") . encodePriority
 
 --------------------------------------------------------------------------------
 -- | The source code file generating this message.


### PR DESCRIPTION
- export `encodePriority`
- add `Mode` for waiting (waits for new events in journal), terminating (terminates the stream when last event is read)
- add `FromRealtime` to `Start` ADT to support seek to defined timestamp before starting the stream

I am working on a tool, where I need a functionality introduced in this pull request. I understand that breaking change is unfortunate so I leave it up to your consideration whether you want to have it in upstream repository.

I have also fixed some GHC warnings along the way, I hope you don't mind.

As I am not seasoned haskell contributor I would be happy to hear any feedback and I am happy to make changes/improvements if necessary.