### PR TITLE
Journal.hsc: Fix compiler warning

### DIFF
--- a/src/Systemd/Journal.hsc
+++ b/src/Systemd/Journal.hsc
@@ -439,7 +439,7 @@ openJournal flags start journalFilter threshold =
         go journalPtr
 
       EQ -> when (sdJournalDirection == Forwards) $ do
-        liftIO $ sdJournalWait journalPtr (-1)
+        liftIO $ sdJournalWait journalPtr maxBound
         go journalPtr
 
       LT -> error $ "sd_journal_next: " ++ show progressedBy


### PR DESCRIPTION
Use `maxBound :: Word64` to instead of `-1`.