### PR TITLE
Push base and semigroups versions

### DIFF
--- a/libsystemd-journal.cabal
+++ b/libsystemd-journal.cabal
@@ -16,7 +16,7 @@ extra-source-files:
 
 library
   exposed-modules:     Systemd.Journal
-  build-depends:       base >=4.6 && <4.15
+  build-depends:       base >=4.6 && <4.17
                      , bytestring >= 0.9.1
                      , pipes >= 4.0
                      , pipes-safe >= 2.0
@@ -29,7 +29,7 @@ library
                      , hashable >= 1.1.2.5
                      , hsyslog
                      , uniplate >= 1.6
-                     , semigroups >= 0.1 && < 0.20
+                     , semigroups >= 0.1 && < 0.21
   hs-source-dirs:      src
   default-language:    Haskell2010
   pkgconfig-depends: libsystemd >= 209


### PR DESCRIPTION
It builds on the current Debian sid (with base 4.15) and stack's `nightly-2022-07-20` resolver (with base 4.16, semigroups 0.20).