### PR TITLE
Loosen various dependency version constraints

### DIFF
--- a/libsystemd-journal.cabal
+++ b/libsystemd-journal.cabal
@@ -22,7 +22,7 @@ library
                      , pipes-safe >= 2.0
                      , text >= 0.1 
                      , transformers >= 0.3
-                     , unix-bytestring >= 0.3.2 && < 0.4
+                     , unix-bytestring >= 0.3.2 && < 0.5
                      , vector >= 0.4 && < 0.13
                      , uuid
                      , unordered-containers >= 0.1 && < 0.3

--- a/libsystemd-journal.cabal
+++ b/libsystemd-journal.cabal
@@ -16,11 +16,11 @@ extra-source-files:
 
 library
   exposed-modules:     Systemd.Journal
-  build-depends:       base >=4.6 && <4.15
+  build-depends:       base >=4.6 && <4.17
                      , bytestring >= 0.9.1
                      , pipes >= 4.0
                      , pipes-safe >= 2.0
-                     , text >= 0.1 && < 1.3
+                     , text >= 0.1 
                      , transformers >= 0.3
                      , unix-bytestring >= 0.3.2 && < 0.4
                      , vector >= 0.4 && < 0.13
@@ -29,7 +29,7 @@ library
                      , hashable >= 1.1.2.5
                      , hsyslog
                      , uniplate >= 1.6
-                     , semigroups >= 0.1 && < 0.20
+                     , semigroups >= 0.1 && < 0.21
   hs-source-dirs:      src
   default-language:    Haskell2010
   pkgconfig-depends: libsystemd >= 209


### PR DESCRIPTION
Like !26, this bumps the maximum versions for `base` and `semigroups` to `4.17` and `0.21` respectively. In addition, it removes the maximum version of `text`, as it seems to work fine with version `2.0` and up.