### PR TITLE
Make it build with ghc 9.12

### DIFF
--- a/libsystemd-journal.cabal
+++ b/libsystemd-journal.cabal
@@ -21,7 +21,7 @@ extra-source-files:
 
 library
   exposed-modules:     Systemd.Journal
-  build-depends:     , base ^>= 4.16 || ^>= 4.17 || ^>= 4.18 || ^>= 4.19 || ^>= 4.20
+  build-depends:     , base ^>= 4.16 || ^>= 4.17 || ^>= 4.18 || ^>= 4.19 || ^>= 4.20 || ^>= 4.21
                      , bytestring ^>= 0.11.1 || ^>= 0.12
                      , pipes ^>= 4.3.10
                      , pipes-safe ^>= 2.3.1


### PR DESCRIPTION
With this change I still need

```
allow-newer:
  pipes-safe:base
```
for which a PR has already been raised: https://github.com/Gabriella439/Haskell-Pipes-Safe-Library/pull/70